### PR TITLE
Ximalaya: filter out null thumbnails

### DIFF
--- a/youtube_dl/extractor/ximalaya.py
+++ b/youtube_dl/extractor/ximalaya.py
@@ -125,7 +125,7 @@ class XimalayaIE(XimalayaBaseIE):
         thumbnails = []
         for k in audio_info.keys():
             # cover pics kyes like: cover_url', 'cover_url_142'
-            if k.startswith('cover_url'):
+            if k.startswith('cover_url') and audio_info[k]:
                 thumbnail = {'name': k, 'url': audio_info[k]}
                 if k == 'cover_url_142':
                     thumbnail['width'] = 180


### PR DESCRIPTION
Hey,

Following up my comment: 

https://github.com/ytdl-org/youtube-dl/pull/18749#issuecomment-483589641

I've fixed it - looks like cover_url field in my URL was null - now the audio tracks are downloading.

Thanks for your work BTW